### PR TITLE
Correction of the direction of travel

### DIFF
--- a/server/move.py
+++ b/server/move.py
@@ -23,11 +23,11 @@ Motor_B_Pin2  = 18
 Dir_forward   = 1
 Dir_backward  = 0
 
-left_forward  = 1
-left_backward = 0
+left_forward  = 0
+left_backward = 1
 
-right_forward = 0
-right_backward= 1
+right_forward = 1
+right_backward= 0
 
 pwn_A = 0
 pwm_B = 0
@@ -101,11 +101,11 @@ def move(speed, direction, turn, radius=0.6):   # 0 < radius <= 1
 	#speed = 100
 	if direction == 'forward':
 		if turn == 'right':
-			motor_left(0, left_backward, int(speed*radius))
-			motor_right(1, right_forward, speed)
+			motor_left(0, left_forward, int(speed*radius))
+			motor_right(1, right_backward, speed)
 		elif turn == 'left':
-			motor_left(1, left_forward, speed)
-			motor_right(0, right_backward, int(speed*radius))
+			motor_left(1, left_backward, speed)
+			motor_right(0, right_forward, int(speed*radius))
 		else:
 			motor_left(1, left_forward, speed)
 			motor_right(1, right_forward, speed)
@@ -121,11 +121,11 @@ def move(speed, direction, turn, radius=0.6):   # 0 < radius <= 1
 			motor_right(1, right_backward, speed)
 	elif direction == 'no':
 		if turn == 'right':
-			motor_left(1, left_backward, speed)
-			motor_right(1, right_forward, speed)
-		elif turn == 'left':
 			motor_left(1, left_forward, speed)
 			motor_right(1, right_backward, speed)
+		elif turn == 'left':
+			motor_left(1, left_backward, speed)
+			motor_right(1, right_forward, speed)
 		else:
 			motorStop()
 	else:

--- a/server/move.py
+++ b/server/move.py
@@ -29,7 +29,7 @@ left_backward = 1
 right_forward = 1
 right_backward= 0
 
-pwn_A = 0
+pwm_A = 0
 pwm_B = 0
 
 def motorStop():#Motor stops


### PR DESCRIPTION
- renaming _master_ branch to _main_
- I think there is a bug. If the robot is to move to the left, the left wheels must turn backwards and the right wheels forwards and vice versa. Currently it is the other way around.